### PR TITLE
Add wcs_help_tip() as customAutoEscapedFunctions

### DIFF
--- a/Prospress/ruleset.xml
+++ b/Prospress/ruleset.xml
@@ -90,7 +90,7 @@
 		<exclude-pattern>*/templates/emails/plain/*</exclude-pattern>
 		<properties>
 			<!-- e.g. body_class, the_content, the_excerpt -->
-			<property name="customAutoEscapedFunctions" type="array" value="woocommerce_wp_select"/>
+			<property name="customAutoEscapedFunctions" type="array" value="woocommerce_wp_select, wcs_help_tip"/>
 			<!-- e.g. esc_attr, esc_html, esc_url-->
 			<property name="customSanitizingFunctions" type="array" value="wcs_json_encode"/>
 			<!-- e.g. _deprecated_argument, printf, _e-->


### PR DESCRIPTION
To ensure https://github.com/Prospress/woocommerce-subscriptions/pull/1621 passes.
