### PR TITLE
Add `htmlspecialchars()` to `customEscapingFunctions`

### DIFF
--- a/Prospress/ruleset.xml
+++ b/Prospress/ruleset.xml
@@ -92,7 +92,7 @@
 			<!-- e.g. body_class, the_content, the_excerpt -->
 			<property name="customAutoEscapedFunctions" type="array" value="0=>woocommerce_wp_select,1=>wcs_help_tip"/>
 			<!-- e.g. esc_attr, esc_html, esc_url-->
-			<property name="customEscapingFunctions" type="array" value="wcs_json_encode"/>
+			<property name="customEscapingFunctions" type="array" value="0=>wcs_json_encode,1=>htmlspecialchars"/>
 			<!-- e.g. _deprecated_argument, printf, _e-->
 			<property name="customPrintingFunctions" type="array" value=""/>
 		</properties>


### PR DESCRIPTION
Because it's not currently recognised as a valid escaping function:
https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/708

But has issues, see https://github.com/woocommerce/woocommerce/issues/9287
and https://github.com/woocommerce/woocommerce/commit/cf54ea8fc055e079dc956889700af1c7cf614246