### PR TITLE
Adding Custom escaping function wp_kses_allow_underscores

### DIFF
--- a/Prospress/ruleset.xml
+++ b/Prospress/ruleset.xml
@@ -92,7 +92,7 @@
 			<!-- e.g. body_class, the_content, the_excerpt -->
 			<property name="customAutoEscapedFunctions" type="array" value="0=>woocommerce_wp_select,1=>wcs_help_tip"/>
 			<!-- e.g. esc_attr, esc_html, esc_url-->
-			<property name="customEscapingFunctions" type="array" value="0=>wcs_json_encode,1=>htmlspecialchars"/>
+			<property name="customEscapingFunctions" type="array" value="0=>wcs_json_encode,1=>htmlspecialchars,2=>wp_kses_allow_underscores"/>
 			<!-- e.g. _deprecated_argument, printf, _e-->
 			<property name="customPrintingFunctions" type="array" value=""/>
 		</properties>


### PR DESCRIPTION
Currently `wp_kses()` does not allow attribute names with underscores.
This fix introduces a custom escaping function `wp_kses_allow_underscores()` to fix this issue.